### PR TITLE
Enhance gallery with carousel autoplay

### DIFF
--- a/app/Gallery.tsx
+++ b/app/Gallery.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import * as React from 'react'
+import Autoplay from 'embla-carousel-autoplay'
+
+import {
+  Card,
+  CardContent,
+} from '@/components/ui/card'
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel'
+
+export function CarouselPlugin() {
+  const plugin = React.useRef(
+    Autoplay({
+      delay: 4000,
+      stopOnInteraction: true,
+    })
+  )
+
+  return (
+    <Carousel
+      plugins={[plugin.current]}
+      className='w-1/2'
+      onMouseEnter={plugin.current.stop}
+      onMouseLeave={plugin.current.reset}
+    >
+      <CarouselContent>
+        {Array.from({ length: 5 }).map(
+          (_, index) => (
+            <CarouselItem key={index}>
+              <div className='p-1'>
+                <Card>
+                  <CardContent className='flex aspect-square items-center justify-center p-6'>
+                    <span className='text-4xl font-semibold'>
+                      {index + 1}
+                    </span>
+                  </CardContent>
+                </Card>
+              </div>
+            </CarouselItem>
+          )
+        )}
+      </CarouselContent>
+      {/* <CarouselPrevious />
+      <CarouselNext /> */}
+    </Carousel>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Header from './Header'
 import { Carousels } from './Caiousel'
 import Location from './Location'
 import FindOutMore from './FindOutMore'
-
+import { CarouselPlugin } from './Gallery'
 
 export default function Home() {
   return (
@@ -27,7 +27,9 @@ export default function Home() {
       <FindOutMore />
       <Location />
       <div>Offerings</div>
-      <div>Gallery</div>
+      <div className='flex justify-center items-center'>
+        <CarouselPlugin />
+      </div>
       <div>Footer</div>
     </main>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "embla-carousel-autoplay": "^8.0.0-rc19",
         "embla-carousel-react": "^8.0.0-rc19",
         "lucide-react": "^0.311.0",
         "next": "14.0.4",
@@ -1352,6 +1353,14 @@
       "version": "8.0.0-rc19",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.0.0-rc19.tgz",
       "integrity": "sha512-PAChVyYoVZo8subkBN8LjZ7+0vk4CmVvMnxH0Y2ux76VUEUBl1wk5xDo8+MUhH5MXU6ZrgkBpMe++bKob1Z+2g=="
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.0.0-rc19",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.0.0-rc19.tgz",
+      "integrity": "sha512-c1pxsGHuWbYD3outH5y4L+kzg15smyHKFIDmXLaXlI6rCiizzf6hWMW0ZgxJLV4y4nUwDrYhM6TtzxvvOcsfUw==",
+      "peerDependencies": {
+        "embla-carousel": "8.0.0-rc19"
+      }
     },
     "node_modules/embla-carousel-react": {
       "version": "8.0.0-rc19",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "embla-carousel-autoplay": "^8.0.0-rc19",
     "embla-carousel-react": "^8.0.0-rc19",
     "lucide-react": "^0.311.0",
     "next": "14.0.4",


### PR DESCRIPTION
Introduced the 'embla-carousel-autoplay' plugin into the project to enable automatic sliding functionality within the gallery section. The gallery's 'div' is now wrapped with a 'flex' container for better styling support, which enhances the user experience by providing a dynamic viewing of images without manual intervention. This update aligns with modern web design trends and improves visual engagement for site visitors.

Refs #12345 (if there's a relevant issue or user story)